### PR TITLE
Make Errorcodes great again (well, sorta)

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -41,6 +41,8 @@
 #define BGM_INSTALL		2
 #define UNINSTALL		3
 
+#define ERROR 0
+#define WARNING 1
 static const int THEMES_PER_SCREEN = 4;
 
 enum TextureID {

--- a/include/draw.h
+++ b/include/draw.h
@@ -40,5 +40,5 @@ void draw_theme_install(int install_type);
 void draw_theme_interface(Theme_s * themes_list, int theme_count, int selected_theme, bool preview_mode, int shuffle_theme_count);
 void draw_splash_install(int install_type);
 void draw_splash_interface(Splash_s *splashes_list, int splash_count, int selected_splash, bool preview_mode);
-void throw_error(char* error);
+void throw_error(char* error, int error_type);
 #endif

--- a/include/draw.h
+++ b/include/draw.h
@@ -40,5 +40,5 @@ void draw_theme_install(int install_type);
 void draw_theme_interface(Theme_s * themes_list, int theme_count, int selected_theme, bool preview_mode, int shuffle_theme_count);
 void draw_splash_install(int install_type);
 void draw_splash_interface(Splash_s *splashes_list, int splash_count, int selected_splash, bool preview_mode);
-
+void throw_error(char* error);
 #endif

--- a/source/draw.c
+++ b/source/draw.c
@@ -37,8 +37,8 @@ enum Colors {
     COLOR_WHITE = RGBA8(255, 255, 255, 255),
     COLOR_CURSOR = RGBA8(200, 200, 200, 255),
     COLOR_BLACK = RGBA8(0, 0, 0, 255),
-	COLOR_RED = RGBA8(200, 0, 0, 255),
-	COLOR_YELLOW = RGBA8(239, 220, 11, 255),
+    COLOR_RED = RGBA8(200, 0, 0, 255),
+    COLOR_YELLOW = RGBA8(239, 220, 11, 255),
 };
 
 void init_screens(void)
@@ -145,16 +145,16 @@ void draw_base_interface(void)
     pp2d_draw_on(GFX_TOP);
 }
 void throw_error(char* error, int error_type) {
-	draw_base_interface();
-	switch (error_type) {
-		case ERROR:
-			pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_RED, error);
-			break;
-		case WARNING:
-			pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_YELLOW, error);
-			break;
-	}
-	pp2d_end_draw();
+    draw_base_interface();
+    switch (error_type) {
+        case ERROR:
+            pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_RED, error);
+            break;
+        case WARNING:
+            pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_YELLOW, error);
+            break;
+    }
+    pp2d_end_draw();
 }
 void draw_theme_install(int install_type)
 {
@@ -220,7 +220,7 @@ void draw_theme_interface(Theme_s * themes_list, int theme_count, int selected_t
         pp2d_draw_wtext(200, 180, 0.6, 0.6, COLOR_WHITE, L"\uE001 Queue Shuffle");
         pp2d_draw_wtext(20, 210, 0.6, 0.6, COLOR_WHITE, L"\uE002 Install BGM");
         pp2d_draw_wtext(200, 210, 0.6, 0.6, COLOR_WHITE, L"\uE003 Preview Theme");
-		pp2d_draw_wtext(130, 120, 0.6, 0.6, COLOR_WHITE, L"\uE005 Scan QRCode");
+        pp2d_draw_wtext(130, 120, 0.6, 0.6, COLOR_WHITE, L"\uE005 Scan QRCode");
         pp2d_draw_on(GFX_BOTTOM);
 
         pp2d_draw_textf(7, 3, 0.6, 0.6, COLOR_WHITE, "Selected: %i/10", shuffle_theme_count);
@@ -316,7 +316,7 @@ void draw_splash_interface(Splash_s *splashes_list, int splash_count, int select
         pp2d_draw_text_center(GFX_TOP, 4, 0.5, 0.5, COLOR_WHITE, "Splash mode");
 
         pp2d_draw_wtext_center(GFX_TOP, 180, 0.7, 0.7, COLOR_WHITE, L"\uE000 Install Splash    \uE004 Switch to Themes");
-		pp2d_draw_wtext_center(GFX_TOP, 210, 0.7, 0.7, COLOR_WHITE, L"\uE002 Delete current Splash");
+        pp2d_draw_wtext_center(GFX_TOP, 210, 0.7, 0.7, COLOR_WHITE, L"\uE002 Delete current Splash");
         pp2d_draw_on(GFX_BOTTOM);
         for (int i = 0; i < splash_count; i++) {
             if (splash_count <= THEMES_PER_SCREEN)

--- a/source/draw.c
+++ b/source/draw.c
@@ -37,6 +37,7 @@ enum Colors {
     COLOR_WHITE = RGBA8(255, 255, 255, 255),
     COLOR_CURSOR = RGBA8(200, 200, 200, 255),
     COLOR_BLACK = RGBA8(0, 0, 0, 255),
+	COLOR_RED = RGBA8(200, 0, 0, 255)
 };
 
 void init_screens(void)
@@ -142,7 +143,11 @@ void draw_base_interface(void)
     pp2d_draw_text(7, 219, 0.6, 0.6, COLOR_WHITE, VERSION);
     pp2d_draw_on(GFX_TOP);
 }
-
+void throw_error(char* error) {
+	draw_base_interface();
+	pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_WHITE, error);
+	pp2d_end_draw();
+}
 void draw_theme_install(int install_type)
 {
     draw_base_interface();

--- a/source/draw.c
+++ b/source/draw.c
@@ -37,7 +37,8 @@ enum Colors {
     COLOR_WHITE = RGBA8(255, 255, 255, 255),
     COLOR_CURSOR = RGBA8(200, 200, 200, 255),
     COLOR_BLACK = RGBA8(0, 0, 0, 255),
-	COLOR_RED = RGBA8(200, 0, 0, 255)
+	COLOR_RED = RGBA8(200, 0, 0, 255),
+	COLOR_YELLOW = RGBA8(239, 220, 11, 255),
 };
 
 void init_screens(void)
@@ -143,9 +144,16 @@ void draw_base_interface(void)
     pp2d_draw_text(7, 219, 0.6, 0.6, COLOR_WHITE, VERSION);
     pp2d_draw_on(GFX_TOP);
 }
-void throw_error(char* error) {
+void throw_error(char* error, int error_type) {
 	draw_base_interface();
-	pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_WHITE, error);
+	switch (error_type) {
+		case ERROR:
+			pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_RED, error);
+			break;
+		case WARNING:
+			pp2d_draw_text(70, 120, 0.8, 0.8, COLOR_YELLOW, error);
+			break;
+	}
 	pp2d_end_draw();
 }
 void draw_theme_install(int install_type)

--- a/source/main.c
+++ b/source/main.c
@@ -122,7 +122,7 @@ int main(void)
         }
         else if (kDown & KEY_L)
         {
-			throw_error("TEST");
+			splash_mode = !splash_mode;
         } else if (kDown & KEY_R)
         {
 			if (splash_mode || preview_mode) {

--- a/source/main.c
+++ b/source/main.c
@@ -122,7 +122,7 @@ int main(void)
         }
         else if (kDown & KEY_L)
         {
-            splash_mode = !splash_mode;
+			throw_error("TEST");
         } else if (kDown & KEY_R)
         {
 			if (splash_mode || preview_mode) {

--- a/source/main.c
+++ b/source/main.c
@@ -122,17 +122,17 @@ int main(void)
         }
         else if (kDown & KEY_L)
         {
-			splash_mode = !splash_mode;
+            splash_mode = !splash_mode;
         } else if (kDown & KEY_R)
         {
-			if (splash_mode || preview_mode) {
-				continue;
-			} else {
-				qr_mode = !qr_mode;
-				if (qr_mode) init_qr();
-				else exit_qr();
-				continue;
-			}
+            if (splash_mode || preview_mode) {
+                continue;
+            } else {
+                qr_mode = !qr_mode;
+                if (qr_mode) init_qr();
+                else exit_qr();
+                continue;
+            }
         }
 
         if (qr_mode) continue;
@@ -291,7 +291,7 @@ int main(void)
         else if (kHeld & KEY_CPAD_DOWN)
         {
             svcSleepThread(100000000);
-			
+            
             if (splash_mode)
             {
                 selected_splash++;


### PR DESCRIPTION
* Basic error code support added
`throw_error("error code", WARNING)` for a yellow error text and `throw_error("error code", ERROR)` for red text.
however, error codes are not being paused yet, they just flash up for a second and then disappear. this has to be done later.
