### PR TITLE
Fixed crash when installing themes without bgm

### DIFF
--- a/include/fs.h
+++ b/include/fs.h
@@ -39,7 +39,7 @@ Result close_archives(void);
 u64 file_to_buf(FS_Path path, FS_Archive archive, char** buf);
 u32 zip_file_to_buf(char *file_name, u16 *zip_path, char **buf);
 
-u32 buf_to_file(u32 size, char *path, FS_Archive archive, char *buf);
+Result buf_to_file(u32 size, char *path, FS_Archive archive, char *buf);
 void remake_file(char *path, FS_Archive archive, u32 size);
 
 #endif

--- a/source/fs.c
+++ b/source/fs.c
@@ -151,17 +151,16 @@ u32 zip_file_to_buf(char *file_name, u16 *zip_path, char **buf)
     }
 }
 
-u32 buf_to_file(u32 size, char *path, FS_Archive archive, char *buf)
+Result buf_to_file(u32 size, char *path, FS_Archive archive, char *buf)
 {
     Handle handle;
-    u32 bytes = 0;
     Result res = FSUSER_OpenFile(&handle, archive, fsMakePath(PATH_ASCII, path), FS_OPEN_WRITE, 0);
     if (R_FAILED(res)) return res;
-    res = FSFILE_Write(handle, &bytes, 0, buf, size, FS_WRITE_FLUSH);
+    res = FSFILE_Write(handle, NULL, 0, buf, size, FS_WRITE_FLUSH);
     if (R_FAILED(res)) return res;
     res = FSFILE_Close(handle);
     if (R_FAILED(res)) return res;
-    return bytes;
+    return 0;
 }
 
 void remake_file(char *path, FS_Archive archive, u32 size)

--- a/source/themes.c
+++ b/source/themes.c
@@ -247,7 +247,6 @@ Result bgm_install(Theme_s bgm_to_install)
 
     if (music_size == 0)
     {
-        free(music);
         music = calloc(1, 3371008);
     } else if (music_size > 3371008) {
         free(music);
@@ -255,7 +254,7 @@ Result bgm_install(Theme_s bgm_to_install)
         return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_TOO_LARGE);
     }
 
-    result = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
+    result = buf_to_file(music_size == 0 ? 3371008 : music_size, "/BgmCache.bin", ArchiveThemeExt, music);
     free(music);
 
     if (!R_SUCCEEDED(result)) return result;
@@ -348,7 +347,6 @@ Result single_install(Theme_s theme_to_install)
 
     if (music_size == 0)
     {
-        free(music);
         music = calloc(1, 3371008);
     } else if (music_size > 3371008) {
         free(music);
@@ -356,7 +354,7 @@ Result single_install(Theme_s theme_to_install)
         return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_TOO_LARGE);
     }
 
-    result = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
+    result = buf_to_file(music_size == 0 ? 3371008 : music_size, "/BgmCache.bin", ArchiveThemeExt, music);
     free(music);
 
     if (!R_SUCCEEDED(result)) return result;

--- a/source/themes.c
+++ b/source/themes.c
@@ -230,8 +230,10 @@ Result bgm_install(Theme_s bgm_to_install)
     memset(&savedata_buf[0x13b8], 0, 8);
     savedata_buf[0x13bd] = 3;
     savedata_buf[0x13b8] = 0xff;
-    u32 size = buf_to_file(savedata_size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
+    Result result = buf_to_file(savedata_size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
     free(savedata_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     if (bgm_to_install.is_zip) // Same as above but this time with bgm
     {
@@ -253,10 +255,10 @@ Result bgm_install(Theme_s bgm_to_install)
         return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_TOO_LARGE);
     }
 
-    size = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
+    result = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
     free(music);
 
-    if (size == 0) return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_NOT_FOUND);
+    if (!R_SUCCEEDED(result)) return result;
 
     file_to_buf(fsMakePath(PATH_ASCII, "/ThemeManage.bin"), ArchiveThemeExt, &thememanage_buf);
     thememanage_buf[0x00] = 1;
@@ -280,8 +282,10 @@ Result bgm_install(Theme_s bgm_to_install)
     memset(&thememanage_buf[0x340], 0, 4);
     memset(&thememanage_buf[0x360], 0, 4);
     memset(&thememanage_buf[0x368], 0, 4);
-    size = buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
+    result = buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
     free(thememanage_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     return 0;
 }
@@ -302,8 +306,10 @@ Result single_install(Theme_s theme_to_install)
     memset(&savedata_buf[0x13b8], 0, 8);
     savedata_buf[0x13bd] = 3;
     savedata_buf[0x13b8] = 0xff;
-    u32 size = buf_to_file(savedata_size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
+    Result result = buf_to_file(savedata_size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
     free(savedata_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     // Open body cache file. Test if theme is zipped
     if (theme_to_install.is_zip)
@@ -325,10 +331,10 @@ Result single_install(Theme_s theme_to_install)
         return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_NOT_FOUND);
     }
 
-    size = buf_to_file(body_size, "/BodyCache.bin", ArchiveThemeExt, body); // Write body data to file
+    result = buf_to_file(body_size, "/BodyCache.bin", ArchiveThemeExt, body); // Write body data to file
     free(body);
 
-    if (size == 0) return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_NOT_FOUND);
+    if (!R_SUCCEEDED(result)) return result;
 
     if (theme_to_install.is_zip) // Same as above but this time with bgm
     {
@@ -350,10 +356,10 @@ Result single_install(Theme_s theme_to_install)
         return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_TOO_LARGE);
     }
 
-    size = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
+    result = buf_to_file(music_size, "/BgmCache.bin", ArchiveThemeExt, music);
     free(music);
 
-    if (size == 0) return MAKERESULT(RL_PERMANENT, RS_CANCELED, RM_APPLICATION, RD_NOT_FOUND);
+    if (!R_SUCCEEDED(result)) return result;
 
     file_to_buf(fsMakePath(PATH_ASCII, "/ThemeManage.bin"), ArchiveThemeExt, &thememanage_buf);
     thememanage_buf[0x00] = 1;
@@ -379,8 +385,10 @@ Result single_install(Theme_s theme_to_install)
     memset(&thememanage_buf[0x340], 0, 4);
     memset(&thememanage_buf[0x360], 0, 4);
     memset(&thememanage_buf[0x368], 0, 4);
-    size = buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
+    result = buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
     free(thememanage_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     return 0;
 }
@@ -427,8 +435,10 @@ Result shuffle_install(Theme_s *themes_list, int theme_count)
         }
     }
 
-    buf_to_file(size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
+    Result result = buf_to_file(size, "/SaveData.dat", ArchiveHomeExt, savedata_buf);
     free(savedata_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     remake_file("/BodyCache_rd.bin", ArchiveThemeExt, 0x150000 * 10); // Enough space for 10 theme files
     Handle body_cache_handle;
@@ -526,8 +536,10 @@ Result shuffle_install(Theme_s *themes_list, int theme_count)
         *bgmsizeloc = bgm_sizes[i];
     }
 
-    buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
+    result = buf_to_file(0x800, "/ThemeManage.bin", ArchiveThemeExt, thememanage_buf);
     free(thememanage_buf);
+
+    if (!R_SUCCEEDED(result)) return result;
 
     return MAKERESULT(RL_SUCCESS, RS_SUCCESS, RM_COMMON, RD_SUCCESS);
 }


### PR DESCRIPTION
When installing a theme without bgm `free(...)` was called on an uninitialized pointer, causing a segfault.

I also noticed `buf_to_file(...)` can either return the number of bytes written or a `Result` on error, with no way to distinguish between those two cases. As the number of written bytes isn't needed anywhere (and should be the same as the passed size on success) I changed it to always return a `Result`.