### PR TITLE
Seems to stop it from crashing on non-theme QR scan.

### DIFF
--- a/source/camera.c
+++ b/source/camera.c
@@ -229,7 +229,7 @@ Result http_get(char *url, char *path)
     //filename = strtok(NULL, "\"");
 
     char *illegal_characters = "\"?;:/\\+";
-	if(!filename)
+    if(!filename)
     {
         free(content_disposition);
         free(new_url);

--- a/source/camera.c
+++ b/source/camera.c
@@ -221,13 +221,21 @@ Result http_get(char *url, char *path)
         free(content_disposition);
         free(new_url);
         free(buf);
+        return ret;
     }
 
     char *filename;
     filename = strtok(content_disposition, "\"");
-    filename = strtok(NULL, "\"");
+    //filename = strtok(NULL, "\"");
 
     char *illegal_characters = "\"?;:/\\+";
+	if(!filename)
+    {
+        free(content_disposition);
+        free(new_url);
+        free(buf);
+        return ret;
+    }
     for (size_t i = 0; i < strlen(filename); i++)
     {
         for (size_t n = 0; n < strlen(illegal_characters); n++)
@@ -250,6 +258,8 @@ Result http_get(char *url, char *path)
             if (buf == NULL)
             {
                 httpcCloseContext(&context);
+                free(content_disposition);
+                free(new_url);
                 free(last_buf);
                 return ret;
             }
@@ -261,6 +271,8 @@ Result http_get(char *url, char *path)
     if (buf == NULL)
     {
         httpcCloseContext(&context);
+        free(content_disposition);
+        free(new_url);
         free(last_buf);
         return -1;
     }
@@ -275,6 +287,10 @@ Result http_get(char *url, char *path)
     else get_themes(&themes_list, &theme_count);
 
     exit_qr();
+
+    free(content_disposition);
+    free(new_url);
+    free(buf);
 
     return 0;
 }

--- a/source/camera.c
+++ b/source/camera.c
@@ -226,7 +226,7 @@ Result http_get(char *url, char *path)
 
     char *filename;
     filename = strtok(content_disposition, "\"");
-    //filename = strtok(NULL, "\"");
+    filename = strtok(NULL, "\"");
 
     char *illegal_characters = "\"?;:/\\+";
     if(!filename)
@@ -234,7 +234,7 @@ Result http_get(char *url, char *path)
         free(content_disposition);
         free(new_url);
         free(buf);
-        return ret;
+        return -1;
     }
     for (size_t i = 0; i < strlen(filename); i++)
     {


### PR DESCRIPTION
Or at least it stopped something-
Scanned qr that was not a theme after testing, didn't crash.
What was that `strtok` with NULL for?

Also added a return if httpcGetResponseHeader return non 0. memory was being freed but no return.