### PR TITLE
fix overlapping icons if you have both themes and splashes

### DIFF
--- a/include/loading.h
+++ b/include/loading.h
@@ -60,6 +60,8 @@ typedef struct {
     Entry_s * entries;
     int entries_count;
 
+    ssize_t icon_id_start;
+
     int scroll;
     int selected_entry;
 

--- a/source/loading.c
+++ b/source/loading.c
@@ -134,7 +134,8 @@ Result load_entries(const char * loading_path, Entry_List_s * list)
 
         current_entry->is_zip = !strcmp(dir_entry.shortExt, "ZIP");
 
-        ssize_t iconID = TEXTURE_ICON + list->entries_count;
+        ssize_t iconID = list->icon_id_start + list->entries_count - 1;
+        DEBUG("id: %u\n", iconID);
         parse_smdh(current_entry, iconID, dir_entry.name);
     }
 

--- a/source/main.c
+++ b/source/main.c
@@ -91,6 +91,34 @@ void change_selected(Entry_List_s * list, int change_value)
         list->selected_entry %= list->entries_count;
 }
 
+void load_lists(Entry_List_s * lists)
+{
+    DEBUG("origin: %u\n", TEXTURE_ICON);
+
+    ssize_t last_icon_id = TEXTURE_ICON;
+    for(int i = 0; i < MODE_AMOUNT; i++)
+    {
+        Entry_List_s * current_list = &lists[i];
+        last_icon_id += current_list->entries_count;
+        free(current_list->entries);
+        memset(current_list, 0, sizeof(Entry_List_s));
+    }
+    pp2d_free_texture(last_icon_id);
+
+    DEBUG("max: %u\n", last_icon_id);
+
+    ssize_t icon_id_start = TEXTURE_ICON;
+    for(int i = 0; i < MODE_AMOUNT; i++)
+    {
+        Entry_List_s * current_list = &lists[i];
+        current_list->icon_id_start = icon_id_start;
+        load_entries(main_paths[i], current_list);
+        icon_id_start += current_list->entries_count;
+    }
+
+    DEBUG("end: %u\n", icon_id_start);
+}
+
 int main(void)
 {
     srand(time(NULL));
@@ -98,9 +126,7 @@ int main(void)
     init_screens();
 
     Entry_List_s lists[MODE_AMOUNT] = {0};
-
-    for(int i = 0; i < MODE_AMOUNT; i++)
-        load_entries(main_paths[i], &lists[i]);
+    load_lists(lists);
 
     EntryMode current_mode = MODE_THEMES;
 
@@ -175,11 +201,7 @@ int main(void)
             CAMU_StartCapture(PORT_BOTH);
 
             if(!qr_mode)
-            {
-                free(current_list->entries);
-                memset(current_list, 0, sizeof(Entry_List_s));
-                load_entries(main_paths[current_mode], current_list);
-            }
+                load_lists(lists);
             continue;
         }
 
@@ -232,6 +254,7 @@ int main(void)
                 case MODE_SPLASHES:
                     draw_install(INSTALL_SPLASH_DELETE);
                     splash_delete();
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
The first loop should handle having a leftover entry if deletion is added in the future
Bottom one is for getting the entries as usual
Any bugs/logic problem in there? Would like to avoid something like the preview problem from c1ef601c2f7ac38db14b16e368e3c4efede3c7e6 again
<img src="https://user-images.githubusercontent.com/16072534/33768396-25d113b4-dc26-11e7-8bf4-5171f251c63c.png" height="250" width="250" alt="
QR code to the .cia for FBI/testing"/>
