### PR TITLE
Memory leak fix and camera multithreading safety improvement

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -30,22 +30,24 @@
 #include "common.h"
 
 typedef struct {
-    u16 *camera_buffer;
-    C2D_Image image;
-    C3D_Tex *tex;
-    Handle mutex;
-    volatile bool finished;
-    volatile bool closed;
-    volatile bool success;
-    Handle cancel;
-    Handle started;
+    u16* camera_buffer;
 
-    bool capturing;
+    Handle event_stop;
+    Thread cam_thread, ui_thread;
+
+    LightEvent event_cam_info, event_ui_info;
+
+    CondVar cond;
+    LightLock mut;
+    u32 num_readers_active;
+    bool writer_waiting;
+    bool writer_active;
+
+    bool any_update;
+
     struct quirc* context;
 } qr_data;
 
 bool init_qr(void);
-void exit_qr(qr_data *data);
-void take_picture(void);
 
 #endif

--- a/include/loading.h
+++ b/include/loading.h
@@ -61,9 +61,9 @@ typedef struct {
 } Icon_s;
 
 typedef struct {
-    u16 name[0x40];
-    u16 desc[0x80];
-    u16 author[0x40];
+    u16 name[0x41];
+    u16 desc[0x81];
+    u16 author[0x41];
 
     // u32 placeholder_color;
 

--- a/include/loading.h
+++ b/include/loading.h
@@ -61,11 +61,11 @@ typedef struct {
 } Icon_s;
 
 typedef struct {
-    u16 name[0x41];
-    u16 desc[0x81];
-    u16 author[0x41];
+    u16 name[0x40];
+    u16 desc[0x80];
+    u16 author[0x40];
 
-    u32 placeholder_color;
+    // u32 placeholder_color;
 
     u16 path[0x106];
     bool is_zip;

--- a/source/camera.c
+++ b/source/camera.c
@@ -282,6 +282,7 @@ static void exit_qr(qr_data *data)
     {
         threadJoin(data->ui_thread, U64_MAX);
         threadFree(data->ui_thread);
+        data->ui_thread = NULL;
     }
 
     LightEvent_Wait(&data->event_cam_info);
@@ -290,9 +291,13 @@ static void exit_qr(qr_data *data)
     {
         threadJoin(data->cam_thread, U64_MAX);
         threadFree(data->cam_thread);
+        data->cam_thread = NULL;
     }
 
     free(data->camera_buffer);
+    data->camera_buffer = NULL;
+    svcCloseHandle(data->event_stop);
+    data->event_stop = 0;
 }
 
 bool init_qr(void)

--- a/source/draw.c
+++ b/source/draw.c
@@ -486,38 +486,20 @@ void draw_text_wrap_scaled(float x, float y, float z, Color color, const char * 
 
 static void draw_entry_info(Entry_s * entry)
 {
-    {
-    u16 author_u16[0x41];
-    memcpy(author_u16, entry->author, 0x40);
-    author_u16[0x40] = 0;
-
     char author[0x41] = {0};
-    utf16_to_utf8((u8*)author, author_u16, 0x40);
+    utf16_to_utf8((u8*)author, entry->author, 0x40);
     draw_c2d_text(20, 35, 0.5, 0.5, 0.5, colors[COLOR_WHITE], &text[TEXT_BY_AUTHOR]);
     float width = 0;
     C2D_TextGetDimensions(&text[TEXT_BY_AUTHOR], 0.5, 0.5, &width, NULL);
     draw_text(20+width, 35, 0.5, 0.5, 0.5, colors[COLOR_WHITE], author);
-    }
-
-    {
-    u16 name_u16[0x41];
-    memcpy(name_u16, entry->name, 0x40);
-    name_u16[0x40] = 0;
 
     char title[0x41] = {0};
-    utf16_to_utf8((u8*)title, name_u16, 0x40);
+    utf16_to_utf8((u8*)title, entry->name, 0x40);
     draw_text(20, 50, 0.5, 0.7, 0.7, colors[COLOR_WHITE], title);
-    }
-
-    {
-    u16 desc_u16[0x81];
-    memcpy(desc_u16, entry->desc, 0x80);
-    desc_u16[0x80] = 0;
 
     char description[0x81] = {0};
-    utf16_to_utf8((u8*)description, desc_u16, 0x80);
+    utf16_to_utf8((u8*)description, entry->desc, 0x80);
     draw_text_wrap(20, 70, 0.5, 0.5, 0.5, colors[COLOR_WHITE], description, 363);
-    }
 }
 
 void draw_grid_interface(Entry_List_s* list, Instructions_s instructions)

--- a/source/draw.c
+++ b/source/draw.c
@@ -486,20 +486,38 @@ void draw_text_wrap_scaled(float x, float y, float z, Color color, const char * 
 
 static void draw_entry_info(Entry_s * entry)
 {
+    {
+    u16 author_u16[0x41];
+    memcpy(author_u16, entry->author, 0x40);
+    author_u16[0x40] = 0;
+
     char author[0x41] = {0};
-    utf16_to_utf8((u8*)author, entry->author, 0x40);
+    utf16_to_utf8((u8*)author, author_u16, 0x40);
     draw_c2d_text(20, 35, 0.5, 0.5, 0.5, colors[COLOR_WHITE], &text[TEXT_BY_AUTHOR]);
     float width = 0;
     C2D_TextGetDimensions(&text[TEXT_BY_AUTHOR], 0.5, 0.5, &width, NULL);
     draw_text(20+width, 35, 0.5, 0.5, 0.5, colors[COLOR_WHITE], author);
+    }
+
+    {
+    u16 name_u16[0x41];
+    memcpy(name_u16, entry->name, 0x40);
+    name_u16[0x40] = 0;
 
     char title[0x41] = {0};
-    utf16_to_utf8((u8*)title, entry->name, 0x40);
+    utf16_to_utf8((u8*)title, name_u16, 0x40);
     draw_text(20, 50, 0.5, 0.7, 0.7, colors[COLOR_WHITE], title);
+    }
+
+    {
+    u16 desc_u16[0x81];
+    memcpy(desc_u16, entry->desc, 0x80);
+    desc_u16[0x80] = 0;
 
     char description[0x81] = {0};
-    utf16_to_utf8((u8*)description, entry->desc, 0x80);
+    utf16_to_utf8((u8*)description, desc_u16, 0x80);
     draw_text_wrap(20, 70, 0.5, 0.5, 0.5, colors[COLOR_WHITE], description, 363);
+    }
 }
 
 void draw_grid_interface(Entry_List_s* list, Instructions_s instructions)
@@ -552,13 +570,18 @@ void draw_grid_interface(Entry_List_s* list, Instructions_s instructions)
         vertical_offset += 24;
         horizontal_offset += 16;
 
+        // theoretically impossible to have no icon when from the api
+        /*
         if(!current_entry->placeholder_color)
         {
+        */
             C2D_Image * image = list->icons[i];
             C2D_DrawImageAt(*image, horizontal_offset, vertical_offset, 0.5f, NULL, 1.0f, 1.0f);
+        /*
         }
         else
             C2D_DrawRectSolid(horizontal_offset, vertical_offset, 0.5f, list->entry_size, list->entry_size, current_entry->placeholder_color);
+        */
 
         if(i == selected_entry)
         {
@@ -713,19 +736,24 @@ void draw_interface(Entry_List_s* list, Instructions_s instructions)
             C2D_DrawSpriteTinted(&sprite_installed, &tint);
         }
 
+        // no icons not allowed anymore
+        /*
         if(!current_entry->placeholder_color)
         {
+        */
             C2D_Image * image = NULL;
             if(list->entries_count > list->entries_loaded*ICONS_OFFSET_AMOUNT)
                 image = list->icons[ICONS_VISIBLE*list->entries_loaded + (i - list->scroll)];
             else
                 image = list->icons[i];
             C2D_DrawImageAt(*image, horizontal_offset, vertical_offset, 0.5f, NULL, 1.0f, 1.0f);
+        /*
         }
         else
         {
             C2D_DrawRectSolid(horizontal_offset, vertical_offset, 0.5f, list->entry_size, list->entry_size, current_entry->placeholder_color);
         }
+        */
     }
 
     char entries_count_str[0x20] = {0};

--- a/source/loading.c
+++ b/source/loading.c
@@ -190,9 +190,11 @@ Result load_entries(const char * loading_path, Entry_List_s * list)
         }
         else
         {
+            const ssize_t len = strulen(path, 0x106);
             struacat(path, "/info.smdh");
             u32 size = file_to_buf(fsMakePath(PATH_UTF16, path), ArchiveSD, &buf);
             if (size == 0) continue;
+            memset(&path[len], 0, (0x106 - len) * sizeof(u16));
         }
 
         list->entries_count++;

--- a/source/loading.c
+++ b/source/loading.c
@@ -106,7 +106,9 @@ static C2D_Image * load_entry_icon(Entry_s entry)
     if(!size) return NULL;
 
     Icon_s * smdh = (Icon_s *)info_buffer;
-    return loadTextureIcon(smdh);
+    C2D_Image* out = loadTextureIcon(smdh);
+    free(info_buffer);
+    return out;
 }
 
 typedef int (*sort_comparator)(const void *, const void *);

--- a/source/main.c
+++ b/source/main.c
@@ -359,7 +359,6 @@ int main(void)
     bool preview_mode = false;
     int preview_offset = 0;
 
-    bool qr_mode = false;
     bool install_mode = false;
     bool extra_mode = false;
     C2D_Image preview = {0};
@@ -407,7 +406,6 @@ int main(void)
             instructions = extra_instructions[index];
         }
 
-        if(qr_mode) take_picture();
         else if(preview_mode)
         {
             draw_preview(preview, preview_offset);
@@ -440,14 +438,14 @@ int main(void)
 
         if(!install_mode && !extra_mode)
         {
-            if(!preview_mode && !qr_mode && kDown & KEY_L) //toggle between splashes and themes
+            if(!preview_mode && kDown & KEY_L) //toggle between splashes and themes
             {
                 switch_mode:
                 current_mode++;
                 current_mode %= MODE_AMOUNT;
                 continue;
             }
-            else if(!qr_mode && !preview_mode && kDown & KEY_R) //toggle QR mode
+            else if(!preview_mode && kDown & KEY_R) //toggle QR mode
             {
                 enable_qr:
                 draw_base_interface();
@@ -480,7 +478,7 @@ int main(void)
 
                 continue;
             }
-            else if(!qr_mode && kDown & KEY_Y && current_list->entries != NULL) //toggle preview mode
+            else if(kDown & KEY_Y && current_list->entries != NULL) //toggle preview mode
             {
                 toggle_preview:
                 if(!preview_mode)
@@ -525,7 +523,7 @@ int main(void)
             }
         }
 
-        if(qr_mode || preview_mode || current_list->entries == NULL)
+        if(preview_mode || current_list->entries == NULL)
             goto touch;
 
         int selected_entry = current_list->selected_entry;


### PR DESCRIPTION
The leak was in the smdh loading code for the original entry load, to get the author/desc/name. it never freed the buffer.
since the smdh is already loaded before even creating the entry, you can just remove that previous step and reuse the check buffer to load the entry info directly, just requires moving the free a bit.
That should allow a lot more entries to be loaded (some poor lad had only 2021 themes make anemone crash, when the limit should be much higher)

Camera syncing was weird for a while, many users had the scanner never work. Tried making it cleaner with a Multiple Reader Single Writer algorithm from wikipedia, neither the ui or the scan can mess up with the camera's write now, and it's just as fast if not faster (some benchmarks done on TP discord) than current implementation.
It's mostly the same guts, just reordered.