### PR TITLE
Networking rework

### DIFF
--- a/include/remote.h
+++ b/include/remote.h
@@ -52,6 +52,6 @@
 #define CACHE_PATH_FORMAT            "/3ds/"  APP_TITLE  "/cache/%"  JSON_INTEGER_FORMAT
 
 bool themeplaza_browser(EntryMode mode);
-u32 http_get(const char *url, char ** filename, char ** buf, InstallType install_type);
+u32 http_get(const char *url, char ** filename, char ** buf, InstallType install_type, const char *mime_type);
 
 #endif

--- a/source/camera.c
+++ b/source/camera.c
@@ -288,18 +288,16 @@ void update_qr(qr_data *data)
                     }
                     else
                     {
+                        // TODO: handle more elegantly
                         throw_error("Zip downloaded is neither\na splash nor a theme.", ERROR_LEVEL_WARNING);
                     }
                 }
                 else
                 {
+                    // TODO: marked for deletion
                     throw_error("File downloaded isn't a zip.", ERROR_LEVEL_WARNING);
                 }
                 free(zip_buf);
-            }
-            else
-            {
-                throw_error("Download failed.", ERROR_LEVEL_WARNING);
             }
 
             free(filename);

--- a/source/camera.c
+++ b/source/camera.c
@@ -229,7 +229,7 @@ void update_qr(qr_data *data)
             draw_install(INSTALL_DOWNLOAD);
             char * zip_buf = NULL;
             char * filename = NULL;
-            u32 zip_size = http_get((char*)scan_data.payload, &filename, &zip_buf, INSTALL_DOWNLOAD);
+            u32 zip_size = http_get((char*)scan_data.payload, &filename, &zip_buf, INSTALL_DOWNLOAD, "application/zip");
 
             if(zip_size != 0)
             {

--- a/source/remote.c
+++ b/source/remote.c
@@ -924,7 +924,9 @@ redirect: // goto here if we need to redirect
             url = new_url;
         }
         else
+        {
             url = redirect_url;
+        }
         DEBUG("HTTP Redirect: %s %s\n", new_url, *redirect_url == '/' ? "relative" : "absolute");
         goto redirect;
     case HTTP_UNACCEPTABLE:
@@ -966,17 +968,15 @@ redirect: // goto here if we need to redirect
         }
     }
 
-    u32 chunk_size;
+    u32 chunk_size = _header.file_size / 4 || 0x80000;
     bool size_correct = false;
     if (_header.file_size)
     {
-        chunk_size = _header.file_size / 4;
         *buf = malloc(_header.file_size);
         size_correct = true;
     }
     else
     {
-        chunk_size = 0x80000;
         *buf = malloc(chunk_size);
     }
 
@@ -1026,7 +1026,7 @@ redirect: // goto here if we need to redirect
         {
             httpcCloseContext(&context);
             free(last_buf);
-            DEBUG("shrinking realloc failed\n"); // 何？
+            DEBUG("shrinking realloc failed\n"); // ??
             return 0;
         }
     }

--- a/source/remote.c
+++ b/source/remote.c
@@ -994,8 +994,11 @@ redirect: // goto here if we need to redirect
     do
     {
         if (size >= _header.file_size)
+        {
             size_correct = false;
-        ret = httpcDownloadData(&context, (u8*)(*buf) + size, chunk_size, &read_size);
+            goto realloc_buf;
+        }
+        ret = httpcDownloadData(&context, (u8 * )(*buf) + size, chunk_size, &read_size);
         size += read_size;
 
         if (size_correct)
@@ -1005,6 +1008,7 @@ redirect: // goto here if we need to redirect
         }
         else if (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING)
         {
+        realloc_buf:
             last_buf = *buf;
 
             *buf = realloc(*buf, size + chunk_size);
@@ -1026,7 +1030,7 @@ redirect: // goto here if we need to redirect
         {
             httpcCloseContext(&context);
             free(last_buf);
-            DEBUG("shrinking realloc failed\n"); // ??
+            DEBUG("shrinking realloc failed\n"); // 何？
             return 0;
         }
     }

--- a/source/remote.c
+++ b/source/remote.c
@@ -778,11 +778,14 @@ static ParseResult parse_header(struct header *out, httpcContext *context, char 
 
     // Content-Type
 
-    httpcGetResponseHeader(context, "Content-Type", content_buf, 1024);
-    if(!strstr(mime, content_buf))
+    if (mime)
     {
-        DEBUG("expected %s received %s\n", mime, content_buf);
-        return SERVER_IS_MISBEHAVING;
+        httpcGetResponseHeader(context, "Content-Type", content_buf, 1024);
+        if (!strstr(mime, content_buf))
+        {
+            DEBUG("expected %s received %s\n", mime, content_buf);
+            return SERVER_IS_MISBEHAVING;
+        }
     }
 
 
@@ -869,7 +872,8 @@ u32 http_get(const char *url, char ** filename, char ** buf, InstallType install
         httpcSetKeepAlive(&context, HTTPC_KEEPALIVE_ENABLED);
         httpcAddRequestHeaderField(&context, "User-Agent", USER_AGENT);
         httpcAddRequestHeaderField(&context, "Connection", "Keep-Alive");
-        httpcAddRequestHeaderField(&context, "Accept", acceptable_mime_types);
+        if (acceptable_mime_types)
+            httpcAddRequestHeaderField(&context, "Accept", acceptable_mime_types);
 
         ret = httpcBeginRequest(&context);
         if (ret != 0)

--- a/source/remote.c
+++ b/source/remote.c
@@ -910,17 +910,17 @@ redirect: // goto here if we need to redirect
         break;
     case REDIRECT:
         if (redirect_url == NULL)
-            redirect_url = malloc(0x1000);
-        httpcGetResponseHeader(&context, "Location", redirect_url, 0x1000);
+            redirect_url = malloc(0x824);
+        httpcGetResponseHeader(&context, "Location", redirect_url, 0x824);
         httpcCloseContext(&context);
         if (*redirect_url == '/') // if relative URL
         {
             if (new_url == NULL)
-                new_url = malloc(0x1000);
+                new_url = malloc(0x824);
             strcpy(new_url, url);
             // this is good code, i promise
             *(strchr(strchr(strchr(new_url, '/') + 1, '/') + 1, '/')) = '\0';
-            strncat(new_url, redirect_url, 0x1000 - strlen(new_url));
+            strncat(new_url, redirect_url, 0x824 - strlen(new_url));
             url = new_url;
         }
         else

--- a/source/remote.c
+++ b/source/remote.c
@@ -970,10 +970,11 @@ redirect: // goto here if we need to redirect
     char * last_buf;
 
     // TODO: "progress bar"? would just update at estimated intervals, as when not doing chunked read we don't know
-    /*if (_header.file_size != 0)
+    // we could just do a chunked download by a known quantity, e.g. size / 5
+    if (_header.file_size != 0)
     {
         *buf = malloc(_header.file_size);
-        ret = httpcDownloadData(&context, (u8*)(*buf), _header.file_size, &size);
+        ret = httpcDownloadData(&context, (u8 * )(*buf), _header.file_size, &size);
         if (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING)
         {
             // FIXME:
@@ -983,18 +984,14 @@ redirect: // goto here if we need to redirect
             return 0;
         }
     }
-    else*/
-    //{
-        u32 content_size = _header.file_size;
+    else
+    {
         u32 read_size = 0;
         *buf = malloc(0x1000);
         do
         {
             ret = httpcDownloadData(&context, (*(u8 **)buf) + size, 0x1000, &read_size);
             size += read_size;
-
-        if (content_size && install_type != INSTALL_NONE)
-            draw_loading_bar(size, content_size, install_type);
 
             if (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING)
             {
@@ -1019,7 +1016,7 @@ redirect: // goto here if we need to redirect
             DEBUG("realloc\n");
             return 0;
         }
-    //}
+    }
 
     httpcCloseContext(&context);
 


### PR DESCRIPTION
We now have proper HTTP status code handling.

Every HTTP status code we expect to get from a well-behaved server is handled, and there is a default branch handling any that we don't. There are a couple of things left to do, but before #239 gets merged I want to make sure this is in here so that we can make a release.

I've done some testing, and everything works as intended so far as I can see. Obviously no software survives first contact, but I'm fairly confident.

There's a lot of code duplication in here, but that can be resolved in a follow-up commit when the release has been made. I'm happy to call this done for now.