### PR TITLE
make shuffle work on consoles that never used it

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -49,8 +49,9 @@ typedef struct {
     u8 _padding1[0x13b8];
     ThemeEntry_s theme_entry;
     ThemeEntry_s shuffle_themes[MAX_SHUFFLE_THEMES];
-    u8 _padding2[0xb];
-    bool shuffle;
+    u8 shuffle_seedA[0xb];
+    u8 shuffle;
+    u8 shuffle_seedB[0xa];
 } SaveData_dat_s;
 
 typedef struct {

--- a/source/themes.c
+++ b/source/themes.c
@@ -264,7 +264,7 @@ static Result install_theme_internal(Entry_List_s themes, int installmode)
     savedata->theme_entry.type = 3;
     savedata->theme_entry.index = 0xff;
 
-    savedata->shuffle = (installmode & THEME_INSTALL_SHUFFLE);
+    savedata->shuffle = (installmode & THEME_INSTALL_SHUFFLE) ? 1 : 0;
     if(installmode & THEME_INSTALL_SHUFFLE)
     {
         memset(savedata->shuffle_themes, 0, sizeof(ThemeEntry_s)*MAX_SHUFFLE_THEMES);
@@ -273,6 +273,9 @@ static Result install_theme_internal(Entry_List_s themes, int installmode)
             savedata->shuffle_themes[i].type = 3;
             savedata->shuffle_themes[i].index = i;
         }
+        const u8 shuffle_seed[0xB] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+        memcpy(savedata->shuffle_seedA, shuffle_seed, 0xB);
+        memcpy(savedata->shuffle_seedB, shuffle_seed, 0xA);
     }
 
     res = buf_to_file(savedata_size, fsMakePath(PATH_ASCII, "/SaveData.dat"), ArchiveHomeExt, savedata_buf);


### PR DESCRIPTION
Tested on my console (o3ds) and works, needs testing on more people.
If you already used the official shuffle feature, you can test by force by deleting the SaveData.dat file (00000003) in the home menu SD extdata with godmode9. The home menu will recreate it on the next boot, but empty.
You can then apply any theme or shuffle of themes with Anemone.
Values in the array were chosen by a fair dice roll and struct field name are assumptions.