### PR TITLE
Make BUF_TO_READ larger to fix audio in some cases

### DIFF
--- a/include/music.h
+++ b/include/music.h
@@ -34,7 +34,7 @@
 #include <tremor/ivorbisfile.h>
 #include <tremor/ivorbiscodec.h>
 
-#define BUF_TO_READ 40960 // How much data should be buffered at a time
+#define BUF_TO_READ 48000 // How much data should be buffered at a time
 
 typedef struct {
     OggVorbis_File vf;


### PR DESCRIPTION
If the preview .ogg has a samplerate > the BUF_TO_READ constant, there was an out of bounds write to the audio buffers which resulted in crackling.
Thus, upped it to 48000 (0x80-aligned, and pretty much the highest rate anything consumer goes). a bit big, but safe.