### PR TITLE
make audio safer

### DIFF
--- a/include/music.h
+++ b/include/music.h
@@ -46,9 +46,10 @@ typedef struct {
     u32 filesize;
     
     volatile bool stop;
-    Handle finished;
+    Thread playing_thread;
 } audio_s;
 
 void play_audio(audio_s *);
+void stop_audio(audio_s**);
 
 #endif

--- a/source/loading.c
+++ b/source/loading.c
@@ -608,7 +608,6 @@ Result load_audio(Entry_s entry, audio_s *audio)
     }
 
     audio->mix[0] = audio->mix[1] = 1.0f; // Determines volume for the 12 (?) different outputs. See http://smealum.github.io/ctrulib/channel_8h.html#a30eb26f1972cc3ec28370263796c0444
-    svcCreateEvent(&audio->finished, RESET_STICKY);
 
     ndspChnSetInterp(0, NDSP_INTERP_LINEAR); 
     ndspChnSetMix(0, audio->mix); // See mix comment above

--- a/source/main.c
+++ b/source/main.c
@@ -37,7 +37,7 @@
 
 bool quit = false;
 bool dspfirm = false;
-audio_s * audio = NULL;
+static audio_s * audio = NULL;
 static bool homebrew = false;
 static bool installed_themes = false;
 
@@ -165,8 +165,7 @@ void exit_function(bool power_pressed)
 {
     if(audio)
     {
-        audio->stop = true;
-        svcWaitSynchronization(audio->finished, U64_MAX);
+        stop_audio(&audio);
     }
     free_lists();
     svcCloseHandle(update_icons_mutex);
@@ -512,9 +511,7 @@ int main(void)
                     preview_mode = false;
                     if(current_mode == MODE_THEMES && audio)
                     {
-                        audio->stop = true;
-                        svcWaitSynchronization(audio->finished, U64_MAX);
-                        audio = NULL;
+                        stop_audio(&audio);
                     }
                 }
                 continue;
@@ -524,9 +521,7 @@ int main(void)
                 preview_mode = false;
                 if(current_mode == MODE_THEMES && audio)
                 {
-                    audio->stop = true;
-                    svcWaitSynchronization(audio->finished, U64_MAX);
-                    audio = NULL;
+                    stop_audio(&audio);
                 }
                 continue;
             }

--- a/source/remote.c
+++ b/source/remote.c
@@ -569,9 +569,7 @@ bool themeplaza_browser(EntryMode mode)
                 preview_mode = false;
                 if (mode == MODE_THEMES && audio != NULL)
                 {
-                    audio->stop = true;
-                    svcWaitSynchronization(audio->finished, U64_MAX);
-                    audio = NULL;
+                    stop_audio(&audio);
                 }
             }
         }
@@ -582,9 +580,7 @@ bool themeplaza_browser(EntryMode mode)
                 preview_mode = false;
                 if (mode == MODE_THEMES && audio != NULL)
                 {
-                    audio->stop = true;
-                    svcWaitSynchronization(audio->finished, U64_MAX);
-                    audio = NULL;
+                    stop_audio(&audio);
                 }
             }
             else
@@ -650,9 +646,7 @@ bool themeplaza_browser(EntryMode mode)
                     preview_mode = false;
                     if (mode == MODE_THEMES && audio)
                     {
-                        audio->stop = true;
-                        svcWaitSynchronization(audio->finished, U64_MAX);
-                        audio = NULL;
+                        stop_audio(&audio);
                     }
                     continue;
                 }
@@ -721,9 +715,7 @@ bool themeplaza_browser(EntryMode mode)
 
     if (audio)
     {
-        audio->stop = true;
-        svcWaitSynchronization(audio->finished, U64_MAX);
-        audio = NULL;
+        stop_audio(&audio);
     }
 
     free_preview(preview);


### PR DESCRIPTION
- centralized stop function
- freeing the struct not from the thread while waiting on handle in it
- thread not detached
- fix hang on exit from HM to another app
- probably does the same for #264 