### PR TITLE
Compilation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ CFLAGS	:=	-g -Wall -Wextra -O2 -mword-relocations \
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -D__3DS__ -D_GNU_SOURCE -DVERSION="\"$(VERSION)\"" -DUSER_AGENT="\"$(APP_TITLE)/$(VERSION)\"" -DAPP_TITLE="\"$(APP_TITLE)\""
+CFLAGS	+=	`arm-none-eabi-pkg-config --cflags-only-other vorbisidec libarchive jansson libpng`
 ifneq ($(strip $(CITRA_MODE)),)
 	CFLAGS += -DCITRA_MODE
 endif
@@ -99,7 +100,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpng -lvorbisidec -logg -larchive -ljansson -lcitro2d -lcitro3d -lctrud -lm -lz
+LIBS	:= `arm-none-eabi-pkg-config --libs vorbisidec libarchive jansson libpng` -lcitro2d -lcitro3d -lctrud -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Theme and Splashscreen Manager for the Nintendo 3DS, written in C.
 First of all, make sure devkitARM is properly installed - `$DEVKITPRO` and `$DEVKITARM` should be set to `/opt/devkitpro` and `$DEVKITPRO/devkitARM`, respectively.  
 After that, open the directory you want to clone the repo into, and execute  
 `git clone https://github.com/astronautlevel2/Anemone3DS` (or any other cloning method).  
-To install the prerequisite libraries, begin by ensuring devkitPro pacman (and the base install group, `3ds-dev`) is installed, and then install the dkP packages `3ds-jansson`, `3ds-libvorbisidec`, `3ds-libpng`, and `3ds-libarchive` using `[sudo] [dkp-]pacman -S <package-name>`.  
+To install the prerequisite libraries, begin by ensuring devkitPro pacman (and the base install group, `3ds-dev`) is installed, and then install the dkP packages `3ds-jansson`, `3ds-libvorbisidec`, `3ds-libpng`, `3ds-lz4`, and `3ds-libarchive` using `[sudo] [dkp-]pacman -S <package-name>`.  
 
 After adding [makerom](https://github.com/profi200/Project_CTR) and [bannertool](https://github.com/Steveice10/buildtools) to your PATH, just enter your directory and run `make`. All built binaries will be in `/out/`.
 


### PR DESCRIPTION
Due to an update to libarchive (thanks @LiquidFenrir for figuring it out) the code failed to compile with this error stack:
```
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: C:/devkitPro/portlibs/3ds/lib\libarchive.a(archive_read_support_format_zip.o): in function `archive_read_format_zip_cleanup':
archive_read_support_format_zip.c:(.text.archive_read_format_zip_cleanup+0x12c): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_cleanup+0x140): undefined reference to `BZ2_bzDecompressEnd'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_cleanup+0x154): undefined reference to `ZSTD_freeDStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: C:/devkitPro/portlibs/3ds/lib\libarchive.a(archive_read_support_format_zip.o): in function `zip_read_data_zipx_lzma_alone.isra.0':
archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x58): undefined reference to `lzma_alone_decoder'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x120): undefined reference to `lzma_code'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x20c): undefined reference to `lzma_code'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x30c): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x31c): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.zip_read_data_zipx_lzma_alone.isra.0+0x360): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: C:/devkitPro/portlibs/3ds/lib\libarchive.a(archive_read_support_format_zip.o): in function `archive_read_format_zip_read_data':
archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x160): undefined reference to `ZSTD_createDStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x168): undefined reference to `ZSTD_initDStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x170): undefined reference to `ZSTD_isError'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x18c): undefined reference to `ZSTD_DStreamOutSize'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x214): undefined reference to `ZSTD_decompressStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x21c): undefined reference to `ZSTD_isError'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x6c0): undefined reference to `BZ2_bzDecompressInit'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x768): undefined reference to `BZ2_bzDecompress'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0x780): undefined reference to `BZ2_bzDecompressEnd'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xa44): undefined reference to `lzma_stream_decoder'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xae4): undefined reference to `lzma_code'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xbac): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xe50): undefined reference to `BZ2_bzDecompressEnd'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xe60): undefined reference to `lzma_end'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xeb8): undefined reference to `ZSTD_freeDStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xee0): undefined reference to `ZSTD_freeDStream'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xf78): undefined reference to `ZSTD_getErrorName'
C:/devkitPro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.2.0/../../../../arm-none-eabi/bin/ld.exe: archive_read_support_format_zip.c:(.text.archive_read_format_zip_read_data+0xfac): undefined reference to `ZSTD_getErrorName'
collect2.exe: error: ld returned 1 exit status
make[1]: *** [/opt/devkitpro/devkitARM/3ds_rules:42: /home/user/Documents/GitHub/Anemone3DS/out/Anemone3DS.elf] Error 1
make: *** [Makefile:227: all] Error 2
```
Combined with the extra package I mentioned in the `README.md` this PR will fix the compilation errors that were encontered in #286 