### PR TITLE
Korean support: Show error if patch isn't installed and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A Theme and Splashscreen Manager for the Nintendo 3DS, written in C.
 
+# For Korean system users
+You must install [this Patch](https://github.com/ZeroSkill1/CTR-Hacking/tree/master/General-Hacking/Korean%20HOME%20Menu%20Theme%20Patch) in order to be able to install and use themes. Refer to the "How to use" section in the Readme of this patch for installation instructions.
+
 # Dependencies
  * devkitARM, which can be installed following the instructions [here](https://devkitpro.org/wiki/Getting_Started).
  * jansson, libvorbisidec, libpng, and libarchive, which can be retrieved from [devkitPro pacman](https://devkitpro.org/viewtopic.php?f=13&t=8702).

--- a/include/fs.h
+++ b/include/fs.h
@@ -48,4 +48,6 @@ Result buf_to_file(u32 size, FS_Path path, FS_Archive archive, char *buf);
 void remake_file(FS_Path path, FS_Archive archive, u32 size);
 void save_zip_to_sd(char * filename, u32 size, char * buf, EntryMode mode);
 
+Result getKorPatch(void);
+
 #endif

--- a/source/fs.c
+++ b/source/fs.c
@@ -468,3 +468,11 @@ renamed:
     remake_file(path, ArchiveSD, size);
     buf_to_file(size, path, ArchiveSD, buf);
 }
+
+Result getKorPatch(){
+    Handle handle;
+    Result res = 0;
+    if (R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/code.ips"), FS_OPEN_READ, 0))) return res;
+    if (R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/romfs/petit_LZ.bin"), FS_OPEN_READ, 0))) return res;
+    return 0;
+}

--- a/source/fs.c
+++ b/source/fs.c
@@ -474,5 +474,6 @@ Result getKorPatch(){
     Result res = 0;
     if (R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/code.ips"), FS_OPEN_READ, 0))) return res;
     if (R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/romfs/petit_LZ.bin"), FS_OPEN_READ, 0))) return res;
+    FSFILE_Close(handle);
     return 0;
 }

--- a/source/fs.c
+++ b/source/fs.c
@@ -64,6 +64,10 @@ Result open_archives(void)
             archive1 = 0x000002ce;
             archive2 = 0x00000098;
             break;
+        case 5:
+            archive1 = 0x000002cf;
+            archive2 = 0x000000a9;
+            break;
         default:
             archive1 = 0x00;
             archive2 = 0x00;

--- a/source/main.c
+++ b/source/main.c
@@ -355,6 +355,12 @@ int main(void)
     iconLoadingThread_arg.thread_arg = iconLoadingThread_args_void;
     iconLoadingThread_arg.run_thread = false;
 
+    u8 regionCode;
+    Result korCheck = 0;
+    CFGU_SecureInfoGetRegion(&regionCode);
+    if(regionCode == 5)
+        korCheck = getKorPatch();
+
     #ifndef CITRA_MODE
     if(R_SUCCEEDED(archive_result))
         load_lists(lists);
@@ -380,6 +386,12 @@ int main(void)
             return 0;
         }
 
+        if (R_FAILED(korCheck) && current_mode == MODE_THEMES){
+            throw_error("You must install patches in order to\nuse themes. Check the Readme in\ngithub.com/astronautlevel2/Anemone3DS", ERROR_LEVEL_ERROR);
+            quit = true;
+            continue;
+        }
+        
         #ifndef CITRA_MODE
         if(R_FAILED(archive_result) && current_mode == MODE_THEMES)
         {

--- a/source/themes.c
+++ b/source/themes.c
@@ -445,15 +445,21 @@ Result dump_all_themes(void)
         case CFG_REGION_EUR:
             low_id = 0x00009800;
             break;
+        case CFG_REGION_KOR:
+            low_id = 0x0000a900;
+            break;
         default:
             return -1;
     }
 
-    const char* region_arr[4] = {
+    const char* region_arr[7] = {
         "JPN",
         "USA",
         "EUR",
         "AUS",
+        "CHN",
+        "KOR",
+        "TWN",
     };
 
     const char* language_arr[12] = {


### PR DESCRIPTION
This PR adds a warning if the homemenu patch allowing to use themes is not found, and link to the readme of the repository that show how to install it so Korean users will know about that and can use themes pretty easily