### PR TITLE
Add a special message for Kor if Home menu patch isn't installed

### DIFF
--- a/include/fs.h
+++ b/include/fs.h
@@ -48,4 +48,6 @@ Result buf_to_file(u32 size, FS_Path path, FS_Archive archive, char *buf);
 void remake_file(FS_Path path, FS_Archive archive, u32 size);
 void save_zip_to_sd(char * filename, u32 size, char * buf, EntryMode mode);
 
+Result korPatchInstalled(Result archive_result);
+
 #endif

--- a/source/fs.c
+++ b/source/fs.c
@@ -468,3 +468,14 @@ renamed:
     remake_file(path, ArchiveSD, size);
     buf_to_file(size, path, ArchiveSD, buf);
 }
+
+Result korPatchInstalled(Result archive_result){
+    Handle handle;
+    Result res = 0;
+    if (R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/code.ips"), FS_OPEN_READ, 0))) return res;
+    FSFILE_Close(handle);
+    // The following file is needed to get the "change theme" button on the Home Menu allowing to create extdata, not needed if extdata is already created
+    if (R_FAILED(archive_result) && R_FAILED(res = FSUSER_OpenFile(&handle, ArchiveSD, fsMakePath(PATH_ASCII, "/luma/titles/000400300000A902/romfs/petit_LZ.bin"), FS_OPEN_READ, 0))) return res;
+    FSFILE_Close(handle);
+    return 0;
+}

--- a/source/main.c
+++ b/source/main.c
@@ -362,6 +362,12 @@ int main(void)
     load_lists(lists);
     #endif
 
+    u8 regionCode;
+    Result korCheck = 0;
+    CFGU_SecureInfoGetRegion(&regionCode);
+    if(regionCode == 5)
+        korCheck = korPatchInstalled(archive_result);
+
     EntryMode current_mode = MODE_THEMES;
 
     bool preview_mode = false;
@@ -378,6 +384,12 @@ int main(void)
             free_preview(preview);
             exit_function(false);
             return 0;
+        }
+
+        if (R_FAILED(korCheck) && current_mode == MODE_THEMES){
+            throw_error("Korean HOME Menu patch not found.\nYou must install it in order\nto use themes.", ERROR_LEVEL_ERROR);
+            quit = true;
+            continue;
         }
 
         #ifndef CITRA_MODE


### PR DESCRIPTION
Because Kor doesn't have themes, it requires a patch for it and people who have a modded korean 3ds may not know that.
This pr adds some checks and display a message about installing the patch instead of "set a default theme" because there's no "change theme" in the homemenu.

I tested each cases, and everything works perfectly.