### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Theme and Splashscreen Manager for the Nintendo 3DS, written in C.
 First of all, make sure devkitARM is properly installed - `$DEVKITPRO` and `$DEVKITARM` should be set to `/opt/devkitpro` and `$DEVKITPRO/devkitARM`, respectively.  
 After that, open the directory you want to clone the repo into, and execute  
 `git clone https://github.com/astronautlevel2/Anemone3DS` (or any other cloning method).  
-To install the prerequisite libraries, begin by ensuring devkitPro pacman (and the base install group, `3ds-dev`) is installed, and then install the dkP packages `3ds-jansson`, `3ds-libvorbisidec`, `3ds-libpng`, `3ds-lz4`, and `3ds-libarchive` using `[sudo] [dkp-]pacman -S <package-name>`.  
+To install the prerequisite libraries, begin by ensuring devkitPro pacman (and the base install group, `3ds-dev`) is installed, and then install the dkP packages `3ds-jansson`, `3ds-libvorbisidec`, `3ds-libpng`, `3ds-lz4`, `3ds-libarchive` and `3ds-curl` using `[sudo] [dkp-]pacman -S <package-name>`.  
 
 After adding [makerom](https://github.com/profi200/Project_CTR) and [bannertool](https://github.com/Steveice10/buildtools) to your PATH, just enter your directory and run `make`. All built binaries will be in `/out/`.
 


### PR DESCRIPTION
Included lib-curl as a requirement for successful build. Without it I am getting this error:
```
make
sprites.t3s
Used lz11 for compression
camera.c
colors.c
conversion.c
draw.c
entries_list.c
fs.c
/home/jonaszp/Anemone3DS/source/fs.c: In function 'zip_file_to_buf':
/home/jonaszp/Anemone3DS/source/fs.c:189:33: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  189 |     char * path = calloc(sizeof(char), len * sizeof(u16));
      |                                 ^~~~
/home/jonaszp/Anemone3DS/source/fs.c:189:33: note: earlier argument should specify number of elements, later size of each element
loading.c
main.c
/home/jonaszp/Anemone3DS/source/main.c: In function 'main':
/home/jonaszp/Anemone3DS/source/main.c:442:13: warning: unused variable 'kUp' [-Wunused-variable]
  442 |         u32 kUp = hidKeysUp();
      |             ^~~
/home/jonaszp/Anemone3DS/source/main.c:1044:29: warning: 'current_entry' may be used uninitialized [-Wmaybe-uninitialized]
 1044 |                             splash_install(current_entry);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jonaszp/Anemone3DS/source/main.c:612:19: note: 'current_entry' was declared here
  612 |         Entry_s * current_entry = &current_list->entries[selected_entry];
      |                   ^~~~~~~~~~~~~
music.c
remote.c
/home/jonaszp/Anemone3DS/source/remote.c:28:10: fatal error: curl/curl.h: No such file or directory
   28 | #include <curl/curl.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[1]: *** [/opt/devkitpro/devkitARM//base_rules:39: remote.o] Error 1
make: *** [Makefile:238: all] Error 2
```