### PR TITLE
fix build on new libctru and add lang fetch

### DIFF
--- a/include/ui_strings.h
+++ b/include/ui_strings.h
@@ -193,4 +193,8 @@ typedef enum {
 Language_s init_strings(CFG_Language lang);
 extern Language_s language;
 
+// fetches the system language through CFGU_GetSystemLanguage
+// and returns the appropriate CFG_Language enum value
+CFG_Language get_system_language(void);
+
 #endif

--- a/source/main.c
+++ b/source/main.c
@@ -381,8 +381,7 @@ int main(void)
 {
     srand(time(NULL));
     init_services();
-    CFG_Language lang;
-    CFGU_GetSystemLanguage(&lang);
+    const CFG_Language lang = get_system_language();
     language = init_strings(lang);
     init_screens();
 

--- a/source/ui_strings.c
+++ b/source/ui_strings.c
@@ -2086,3 +2086,12 @@ Language_s init_strings(CFG_Language lang)
             return language_english;
     }
 }
+
+CFG_Language get_system_language(void)
+{
+    u8 lang = CFG_LANGUAGE_EN;
+    // can never fail, cfguInit is one of the very first thing that happens on start
+    // and if it does anyway, default to english
+    CFGU_GetSystemLanguage(&lang);
+    return (CFG_Language)lang;
+}


### PR DESCRIPTION
ACT is now available in libctru, with minor changes to the calling code needed in Anemone, `actInit(true)` to use the `act:u` module for example.  
Defined functions conflicted in name and signature.

Dedicated CFG_Language-getting function added as suggested in the #353 conversation, [approved idea](https://github.com/astronautlevel2/Anemone3DS/pull/353#discussion_r2237047196) but not applied in that PR so /shrug

Not modified inside `dump_all_themes` at themes.c:453 because it is in fact wanted as a number there, to index an array.